### PR TITLE
Fix parallelError.Error

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -17,7 +17,7 @@ type parallelError struct {
 }
 
 func (pe parallelError) Error() string {
-	return fmt.Sprintf("parallel job #%d failed: %s", pe.err)
+	return fmt.Sprintf("parallel job #%d failed: %s", pe.n, pe.err)
 }
 
 func (pe parallelError) Unwrap() error {

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,16 @@
+package jobrun
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestParallelErrors(t *testing.T) {
+	err := parallelError{
+		n:   123,
+		err: fmt.Errorf("hello world"),
+	}
+	if err.Error() != "parallel job #123 failed: hello world" {
+		t.Fatal("unexpected Error()")
+	}
+}


### PR DESCRIPTION
parallelError didn't have enough args.

```
fix-missing-arg:jobrun$ go test -v
=== RUN   TestParallelErrors
--- PASS: TestParallelErrors (0.00s)
PASS
ok      github.com/koron-go/jobrun      0.085s
```